### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -18,8 +18,8 @@ readUserData	KEYWORD2
 writeToRTC	KEYWORD2
 bufferUserData	KEYWORD2
 setUserData	KEYWORD2
-busConnect KEYWORD2
-busDisconnect KEYWORD2
+busConnect	KEYWORD2
+busDisconnect	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -33,4 +33,4 @@ Wire	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-DS1307_DEVICE_ADDRESS LITERAL1
+DS1307_DEVICE_ADDRESS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords